### PR TITLE
Assets frontend version checking

### DIFF
--- a/project/PluginBuild.scala
+++ b/project/PluginBuild.scala
@@ -37,6 +37,7 @@ object PluginBuild extends Build {
         "commons-codec" % "commons-codec" % "1.10",
         "joda-time" % "joda-time" % "2.9.1",
         "org.joda" % "joda-convert" % "1.8.1",
+        "com.typesafe" % "config" % "1.3.0",
         "com.typesafe.play" %% "play-json" % "2.3.10" % "test",
         "org.scalatest" %% "scalatest" % "2.2.4" % "test",
         "org.pegdown" % "pegdown" % "1.5.0" % "test"

--- a/src/main/scala/uk/gov/hmrc/SbtBobbyPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtBobbyPlugin.scala
@@ -54,6 +54,7 @@ object SbtBobbyPlugin extends AutoPlugin {
 
     validate := {
       val isSbtProject = thisProject.value.base.getName == "project" // TODO find less crude way of doing this
+
       Bobby.validateDependencies(
         libraryDependencies.value,
         ProjectPlugin.plugins(buildStructure.value),

--- a/src/main/scala/uk/gov/hmrc/bobby/conf/ApplicationConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/conf/ApplicationConfig.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bobby.conf
+
+import com.typesafe.config.Config
+import scala.util.{Failure, Success, Try}
+
+class ApplicationConfig(config: Config) {
+
+  val assetsFrontendVersion : Option[String] = {
+    val assetsVersion = Try(config.getString("assets.version"))
+
+    assetsVersion match {
+      case Success(version) => Some(version)
+      case Failure(fail) => None
+    }
+  }
+}

--- a/src/main/scala/uk/gov/hmrc/bobby/domain/DeprecatedDependency.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/DeprecatedDependency.scala
@@ -18,35 +18,30 @@ package uk.gov.hmrc.bobby.domain
 
 import org.joda.time.LocalDate
 
-
 sealed trait DependencyType
 
 object DependencyType {
-
   def apply(s: String): DependencyType = s match {
+    case "assets" => Asset
     case "plugins" => Plugin
     case "libraries" => Library
     case _ => Unknown
   }
-
-
-
 }
 
-
-case object Library extends DependencyType
-
+case object Asset extends DependencyType
 case object Plugin extends DependencyType
+case object Library extends DependencyType
 case object Unknown extends DependencyType
 
 case class DeprecatedDependency(dependency: Dependency, range: VersionRange, reason: String, from: LocalDate, _type: DependencyType)
 
 case class DeprecatedDependencies(dependencies: List[DeprecatedDependency] = List.empty) {
-  lazy val (plugins, libs) = dependencies.partition(_._type == Plugin)
+  val assets = dependencies.filter(_._type == Asset)
+  val plugins = dependencies.filter(_._type == Plugin)
+  val libs = dependencies.filter(_._type == Library)
 }
 
 object DeprecatedDependencies {
-
   val EMPTY = DeprecatedDependencies()
-
 }

--- a/src/main/scala/uk/gov/hmrc/bobby/domain/ResultBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/ResultBuilder.scala
@@ -25,13 +25,13 @@ object ResultBuilder {
 
   val logger = ConsoleLogger()
 
-  def calculate(projectLibraries: Seq[ModuleID], projectPlugins: Seq[ModuleID], latestRepoLibraries: Option[Map[ModuleID, Try[Version]]], deprecatedDependencies: DeprecatedDependencies): List[Message] = {
+  def calculate(assetsDependencies: Seq[ModuleID], projectLibraries: Seq[ModuleID], projectPlugins: Seq[ModuleID], latestAssetsRevision: Option[Map[ModuleID, Try[Version]]], latestRepoLibraries: Option[Map[ModuleID, Try[Version]]], deprecatedDependencies: DeprecatedDependencies): List[Message] = {
 
+    val assetsMessages = libraryMessages(assetsDependencies, latestAssetsRevision, deprecatedDependencies.assets)
     val pluginMessages = checkMandatoryMessages(deprecatedDependencies.plugins, projectPlugins)
     val libMessages = libraryMessages(projectLibraries, latestRepoLibraries, deprecatedDependencies.libs)
 
-    (pluginMessages ::: libMessages).sortBy(_.moduleName)
-
+    (assetsMessages ::: pluginMessages ::: libMessages).sortBy(_.moduleName)
   }
 
   private def libraryMessages(projectLibraries: Seq[ModuleID], latestRepoLibraries: Option[Map[ModuleID, Try[Version]]], deprecatedLibraries: List[DeprecatedDependency]): List[Message] = {

--- a/src/sbt-test/sbt-bobby/warning-should-appear-for-assets/build.sbt
+++ b/src/sbt-test/sbt-bobby/warning-should-appear-for-assets/build.sbt
@@ -1,0 +1,28 @@
+//enablePlugins(GitVersioning)
+//enablePlugins(Bobb)
+enablePlugins(SbtBobbyPlugin)
+
+import uk.gov.hmrc.SbtBobbyPlugin.BobbyKeys._
+import sbt.IO._
+
+jsonOutputFileOverride := Some("/tmp/bobby-json-out.json")
+
+scalaVersion := "2.11.6"
+
+libraryDependencies := Seq(
+  "uk.gov.hmrc" %% "play-health" % "0.1.0",
+  "uk.gov.hmrc" %% "play-filters" % "0.1.0")
+
+deprecatedDependenciesUrl := Some(file("dependencies.json").toURL)
+
+val checkVersion = taskKey[Unit]("checks the version is the tag version")
+checkVersion := {
+
+  val json = read(file("/tmp/bobby-json-out.json"))
+  println(json)
+  assert(json.contains("expires"), "Did not show warning for the plugin")
+
+  // play-filters currently appears in the list because it can't be found in a repository
+  //  assert(!json.contains("play-filters"), "Found a reference to play-filters when we shouldn't have")
+
+}

--- a/src/sbt-test/sbt-bobby/warning-should-appear-for-assets/conf/application.conf
+++ b/src/sbt-test/sbt-bobby/warning-should-appear-for-assets/conf/application.conf
@@ -1,0 +1,3 @@
+assets {
+  version = "1.225.0"
+}

--- a/src/sbt-test/sbt-bobby/warning-should-appear-for-assets/dependencies.json
+++ b/src/sbt-test/sbt-bobby/warning-should-appear-for-assets/dependencies.json
@@ -1,0 +1,11 @@
+{
+  "assets": [
+    {
+      "organisation": "",
+      "name": "assets-frontend",
+      "range": "[1.225.0]",
+      "reason": "expires",
+      "from": "2099-01-01"
+    }
+  ]
+}

--- a/src/sbt-test/sbt-bobby/warning-should-appear-for-assets/project/plugins.sbt
+++ b/src/sbt-test/sbt-bobby/warning-should-appear-for-assets/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("uk.gov.hmrc" % "sbt-bobby" % sys.props("project.version"))

--- a/src/sbt-test/sbt-bobby/warning-should-appear-for-assets/test
+++ b/src/sbt-test/sbt-bobby/warning-should-appear-for-assets/test
@@ -1,0 +1,2 @@
+> validate
+> checkVersion

--- a/src/test/scala/uk/gov/hmrc/bobby/conf/ApplicationConfigSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/conf/ApplicationConfigSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bobby.conf
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{FlatSpec, Matchers}
+
+class ApplicationConfigSpec extends FlatSpec with Matchers {
+
+  "Assets frontend Prod version" should "output nothing if it doesn't exist" in {
+    val configWithoutAssets = ConfigFactory.parseString("")
+    val applicationConfig = new ApplicationConfig(configWithoutAssets)
+
+    applicationConfig.assetsFrontendVersion shouldBe None
+  }
+
+  it should "output nothing when 'assets' object is at the root" in {
+    val configWithAssets = ConfigFactory.parseString(
+      """assets {
+        |  version = "2.135.0"
+        |}""".stripMargin)
+    val applicationConfig = new ApplicationConfig(configWithAssets)
+
+    applicationConfig.assetsFrontendVersion.get shouldBe "2.135.0"
+  }
+
+  it should "output nothing when 'assets' object is nested" in {
+    val configWithAssetsInGovUkBlock = ConfigFactory.parseString(
+      """govuk-tax {
+        |  Prod {
+        |    assets {
+        |      version = "1.225.0"
+        |    }
+        |  }
+        |}""".stripMargin)
+    val applicationConfig = new ApplicationConfig(configWithAssetsInGovUkBlock)
+
+    applicationConfig.assetsFrontendVersion shouldBe None
+  }
+
+  it should "output '1.339.0'" in {
+    val configWithAssets = ConfigFactory.parseString(
+      """Prod {
+        |  assets {
+        |    version = "1.339.0"
+        |  }
+        |}""".stripMargin)
+    val applicationConfig = new ApplicationConfig(configWithAssets)
+
+    applicationConfig.assetsFrontendVersion shouldBe None
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/bobby/conf/ConfigurationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/conf/ConfigurationSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.bobby.conf
 
 import org.joda.time.LocalDate
 import org.scalatest.{FlatSpec, Matchers}
-import uk.gov.hmrc.bobby.conf.Configuration
 import uk.gov.hmrc.bobby.domain.{Library, DeprecatedDependency, VersionRange}
 
 class ConfigurationSpec extends FlatSpec with Matchers {

--- a/src/test/scala/uk/gov/hmrc/bobby/conf/ConfigurationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/conf/ConfigurationSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.bobby.conf
 
 import org.joda.time.LocalDate
 import org.scalatest.{FlatSpec, Matchers}
-import uk.gov.hmrc.bobby.domain.{Library, DeprecatedDependency, VersionRange}
+import uk.gov.hmrc.bobby.domain.{Asset, Library, Plugin, VersionRange}
 
 class ConfigurationSpec extends FlatSpec with Matchers {
 
@@ -27,8 +27,11 @@ class ConfigurationSpec extends FlatSpec with Matchers {
     val c = Configuration.parseConfig(
       """
         |{
+        |"assets":[
+        | { "organisation" : "", "name" : "some-assets", "range" : "(,1.0.0)", "reason" : "1.0.0 is outdated", "from" : "2015-01-02" }
+        |],
         |"libraries":[
-        |   { "organisation" : "uk.gov.hmrc", "name" : "some-frontend", "range" : "(,7.4.1)", "reason" : "7.4.1 has important security fixes", "from" : "2015-01-01" }
+        | { "organisation" : "uk.gov.hmrc", "name" : "some-frontend", "range" : "(,7.4.1)", "reason" : "7.4.1 has important security fixes", "from" : "2015-01-01" }
         |],
         |"plugins": [
         | { "organisation" : "uk.gov.hmrc", "name" : "some-plugin", "range" : "(,1.0.0)", "reason" : "1.0.0 is outdated", "from" : "2015-01-02" }
@@ -39,9 +42,17 @@ class ConfigurationSpec extends FlatSpec with Matchers {
         |}
       """.stripMargin)
 
-    c should have size 2
+    c should have size 3
 
-    val (libs, plugins) = c.partition(_._type == Library)
+    val libs = c.filter(_._type == Library)
+    val assets = c.filter(_._type == Asset)
+    val plugins = c.filter(_._type == Plugin)
+
+    assets.head.dependency.organisation shouldBe ""
+    assets.head.dependency.name shouldBe "some-assets"
+    assets.head.range shouldBe VersionRange("(,1.0.0)")
+    assets.head.reason shouldBe "1.0.0 is outdated"
+    assets.head.from shouldBe new LocalDate(2015, 1, 2)
 
     libs.head.dependency.organisation shouldBe "uk.gov.hmrc"
     libs.head.dependency.name shouldBe "some-frontend"

--- a/src/test/scala/uk/gov/hmrc/bobby/domain/DeprecatedDependenciesSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/domain/DeprecatedDependenciesSpec.scala
@@ -22,18 +22,20 @@ import org.scalatest.{Matchers, FlatSpec, WordSpec}
 class DeprecatedDependenciesSpec extends FlatSpec with Matchers{
 
 
-  "DeprecatedDependencies" should "filter plugin and lib dependencies" in {
+  "DeprecatedDependencies" should "filter plugin lib and asset dependencies" in {
 
     val now = new LocalDate()
     val dependencies: List[DeprecatedDependency] = List(
       DeprecatedDependency(Dependency("uk.gov.hmrc", "some-service"), VersionRange("(,1.0.0]"), "testing", now, Library),
       DeprecatedDependency(Dependency("uk.gov.hmrc", "some-service"), VersionRange("(,1.0.0]"), "testing", now, Library),
-      DeprecatedDependency(Dependency("uk.gov.hmrc", "some-service"), VersionRange("(,1.0.0]"), "testing", now, Plugin)
+      DeprecatedDependency(Dependency("uk.gov.hmrc", "some-service"), VersionRange("(,1.0.0]"), "testing", now, Plugin),
+      DeprecatedDependency(Dependency("uk.gov.hmrc", "some-service"), VersionRange("(,1.0.0]"), "testing", now, Asset)
     )
     val deps = DeprecatedDependencies(dependencies)
 
     deps.libs should be(dependencies.take(2))
-    deps.plugins should be(dependencies.takeRight(1))
+    deps.plugins should be(dependencies.slice(2,3))
+    deps.assets should be(dependencies.takeRight(1))
   }
 
 }

--- a/src/test/scala/uk/gov/hmrc/bobby/domain/ResultBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/domain/ResultBuilderSpec.scala
@@ -147,9 +147,7 @@ class ResultBuilderSpec extends FlatSpec with Matchers {
     )
 
     val messages = ResultBuilder.calculate(projectAssets, projectLibraries, projectPlugins, None, None, deprecated)
-    messages.map(_.level).toSet shouldBe Set(WARN, ERROR)
-    messages.count(_.level == WARN) shouldBe 2
-    messages.count(_.level == ERROR) shouldBe 1
+    messages.map(_.level) shouldBe Seq(WARN, ERROR, WARN)
   }
 
   it should "not return error for libraries in the exclude range but not applicable yet" in {

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -10,7 +10,6 @@ resolvers += Resolver.bintrayRepo("hmrc", "releases")
 deprecatedDependenciesUrl := Some(file("dependencies.json").toURL)
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "1.2.0",
   "org.pegdown" % "pegdown" % "1.3.0",
   "org.jsoup" % "jsoup" % "1.6.0",
   "uk.gov.hmrc" %% "play-reactivemongo" % "3.2.0",
@@ -23,7 +22,6 @@ libraryDependencies ++= Seq(
   "uk.gov.hmrc" %% "frontend-bootstrap" % "1.2.1",
   "uk.gov.hmrc" %% "play-partials" % "1.6.0",
   "uk.gov.hmrc" %% "play-authorised-frontend" % "1.2.0",
-  "uk.gov.hmrc" %% "play-config" % "1.0.0",
   "uk.gov.hmrc" %% "play-json-logger" % "1.0.0",
   "uk.gov.hmrc" %% "play-ui" % "1.11.0",
   "uk.gov.hmrc" %% "url-builder" % "0.6.0",

--- a/test-project/conf/application.conf
+++ b/test-project/conf/application.conf
@@ -1,0 +1,3 @@
+assets {
+  version = "1.225.0"
+}

--- a/test-project/dependencies.json
+++ b/test-project/dependencies.json
@@ -1,4 +1,13 @@
 {
+  "assets": [
+    {
+      "organisation": "*",
+      "name": "assets-frontend",
+      "range": "[1.225.0]",
+      "reason": "deprecated",
+      "from": "2010-09-30"
+    }
+  ],
   "libraries": [
     {
       "organisation": "*",


### PR DESCRIPTION
For UI consistency we need a way for frontends to adopt changes to assets.

This change enables this to be done by checking a frontend's `application.conf` against an `assets` rule in the same way `libraries` and `plugins` are. It also checks for the latest version (currently from Nexus - hence the empty org).

Once assets-frontend is building on Jenkins open we can add the `uk.gov.hmrc` org (will raise an issue about that).

### Results Table
<img width="971" alt="screen shot 2016-09-21 at 15 16 06" src="https://cloud.githubusercontent.com/assets/2305016/18744121/6d143c48-80b4-11e6-9a4e-763486d57068.png">
