### PR TITLE
PLATOPS-1903: Handle Play suffixes for cross-compiled libraries

### DIFF
--- a/src/main/scala/uk/gov/hmrc/bobby/domain/VersionRange.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/VersionRange.scala
@@ -72,8 +72,6 @@ object VersionRange {
   // (1.0.0]   x <= 1.0.0  WHY IS THE COMMA NOT MANDATORY?
   // [,1.0.0]  x <= 1.0.0  WHY IS THIS NOT ALLOWED?
 
-  implicit def toVersion(v: String): Version = Version(v)
-
   val ValidFixedVersion          = """^\[(\d+\.\d+.\d+)\]""".r
   val ValidVersionRangeLeftOpen  = """^\(,?(\d+\.\d+.\d+)[\]\)]""".r
   val ValidVersionRangeRightOpen = """^[\[\(](\d+\.\d+.\d+),[\]\)]""".r
@@ -82,11 +80,11 @@ object VersionRange {
 
   def apply(range: String): VersionRange =
     range.replaceAll(" ", "") match {
-      case ValidFixedVersion(v)          => VersionRange(Some(v), true, Some(v), true)
-      case ValidVersionRangeLeftOpen(v)  => VersionRange(None, false, Some(v), range.endsWith("]"))
-      case ValidVersionRangeRightOpen(v) => VersionRange(Some(v), range.startsWith("["), None, false)
+      case ValidFixedVersion(v)          => VersionRange(Some(Version(v)), true, Some(Version(v)), true)
+      case ValidVersionRangeLeftOpen(v)  => VersionRange(None, false, Some(Version(v)), range.endsWith("]"))
+      case ValidVersionRangeRightOpen(v) => VersionRange(Some(Version(v)), range.startsWith("["), None, false)
       case ValidVersionRangeBetween(v1, v2) =>
-        VersionRange(Some(v1), range.startsWith("["), Some(v2), range.endsWith("]"))
+        VersionRange(Some(Version(v1)), range.startsWith("["), Some(Version(v2)), range.endsWith("]"))
       case Qualifier(q) if q.length() > 1 => VersionRange(None, false, None, false, Some(q))
       case _                              => throw new IllegalArgumentException(s"'$range' is not a valid range expression")
     }

--- a/src/sbt-test/sbt-bobby/warning-should-appear-for-plugin/project/plugins.sbt
+++ b/src/sbt-test/sbt-bobby/warning-should-appear-for-plugin/project/plugins.sbt
@@ -1,2 +1,5 @@
+resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
+  Resolver.ivyStylePatterns)
+
 addSbtPlugin("uk.gov.hmrc" % "sbt-bobby"      % sys.props("project.version"))
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.0.0")

--- a/src/sbt-test/sbt-bobby/warning-should-appear/project/plugins.sbt
+++ b/src/sbt-test/sbt-bobby/warning-should-appear/project/plugins.sbt
@@ -1,1 +1,4 @@
+resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
+  Resolver.ivyStylePatterns)
+
 addSbtPlugin("uk.gov.hmrc" % "sbt-bobby" % sys.props("project.version"))

--- a/src/test/scala/uk/gov/hmrc/bobby/domain/VersionRangeSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/domain/VersionRangeSpec.scala
@@ -165,6 +165,11 @@ class VersionRangeSpec extends FlatSpec with Matchers {
     VersionRange("(1.2.0,1.3.0)").toString shouldBe "(1.2.0,1.3.0)"
   }
 
+  it should "understand play cross compiled libraries and ignore play suffixes" in {
+    VersionRange("[1.0.0, 1.0.0]").includes(Version("1.0.0-play-25")) shouldBe true
+    VersionRange("[1.0.0, 1.0.0]").includes(Version("1.0.0-play-26")) shouldBe true
+  }
+
   it should "throw exception when qualifier is not defined" in {
     intercept[IllegalArgumentException] {
       VersionRange("[*-]")


### PR DESCRIPTION
Versions will be treated as if they didn't contain the suffix, e.g.
1.0.0-play-25 and 1.0.0-play-26 can be banned with [1.0.0]