### PR TITLE
BDOG-554 exclude nodes from local projects

### DIFF
--- a/src/main/scala/uk/gov/hmrc/SbtBobbyPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtBobbyPlugin.scala
@@ -63,12 +63,12 @@ object SbtBobbyPlugin extends AutoPlugin {
       // Determine nodes to exclude which are this project or dependent projects from this build
       // Required so multi-project builds with modules that depend on each other don't cause a violation of a SNAPSHOT dependency
       val extracted = Project.extract(state.value)
-      val excludeNodes = buildStructure.value.allProjectRefs.map({ p =>
+      val internalModuleNodes = buildStructure.value.allProjectRefs.map( p =>
         extracted.get(projectID in p)
-      }).distinct.map(_.toDependencyGraph)
+      ).distinct.map(_.toDependencyGraph)
 
       // Construct a complete module graph of the project (not plugin) dependencies, piggy-backing off `sbt-dependency-graph`
-      val projectDependencyGraph: ModuleGraph = GraphOps.cleanGraph((moduleGraph in Compile).value, excludeNodes)
+      val projectDependencyGraph: ModuleGraph = GraphOps.cleanGraph((moduleGraph in Compile).value, excludeNodes = internalModuleNodes)
 
       // Retrieve the plugin dependencies. It would be nice to generate these in the same way via the full ModuleGraph, however the
       // sbt UpdateReport in the pluginData is not rich enough. Seems we have the nodes but not the edges.

--- a/src/main/scala/uk/gov/hmrc/bobby/GraphOps.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/GraphOps.scala
@@ -118,13 +118,14 @@ object GraphOps {
   def toSbtDependencyMap(map: Map[ModuleId, Seq[ModuleId]]): Map[ModuleID, Seq[ModuleID]] =
     map.map { case (k, v) => k.toSbt -> v.map(_.toSbt)}
 
-  def cleanGraph(graph: ModuleGraph, excludeNode: ModuleId): ModuleGraph = {
+  def cleanGraph(graph: ModuleGraph, excludeNodes: Seq[ModuleId]): ModuleGraph = {
+    val stripped = excludeNodes.map(stripUnderscore)
+
     // Remove evicted nodes and the current project node
     val pruned = pruneNodes(
-      pruneEvicted(graph)
-    , m => {
-        stripUnderscore(m.id) == stripUnderscore(excludeNode)
-      })
+      pruneEvicted(graph),
+      m => stripped.contains(stripUnderscore(m.id))
+    )
     // Remove the '_2.11' suffixes etc from the artefact names
     stripScalaVersionSuffix(pruned)
   }

--- a/src/sbt-test/sbt-bobby/multi-project-build/build.sbt
+++ b/src/sbt-test/sbt-bobby/multi-project-build/build.sbt
@@ -1,0 +1,28 @@
+import play.api.libs.json.Json
+import uk.gov.hmrc.SbtBobbyPlugin.BobbyKeys._
+import sbt.IO._
+
+lazy val global = (project in file("."))
+  .enablePlugins(SbtBobbyPlugin)
+  .settings(
+    scalaVersion := "2.12.8"
+  ).aggregate(common, sub)
+
+lazy val common = project
+
+lazy val sub = project
+  .settings(
+    deprecatedDependenciesUrl := Some(file("dependencies.json").toURI.toURL),
+    resolvers += Resolver.bintrayRepo("hmrc", "releases"),
+    TaskKey[Unit]("check") := {
+      val json = Json.parse(read(file("target/bobby-reports/bobby-report.json")))
+      val reasons = (json \\ "deprecationReason").map(_.as[String]).toSet
+      val expected = Set("-")
+
+      assert(reasons == expected, "Did not find expected violations")
+      ()
+    }
+  )
+  .dependsOn(
+    common
+  )

--- a/src/sbt-test/sbt-bobby/multi-project-build/dependencies.json
+++ b/src/sbt-test/sbt-bobby/multi-project-build/dependencies.json
@@ -1,0 +1,11 @@
+{
+  "libraries": [
+    {
+      "organisation": "*",
+      "name": "*",
+      "range": "[*-SNAPSHOT]",
+      "reason": "No snapshot dependencies permitted",
+      "from": "2015-03-16"
+    }
+  ]
+}

--- a/src/sbt-test/sbt-bobby/multi-project-build/project/build.properties
+++ b/src/sbt-test/sbt-bobby/multi-project-build/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.4

--- a/src/sbt-test/sbt-bobby/multi-project-build/project/plugins.sbt
+++ b/src/sbt-test/sbt-bobby/multi-project-build/project/plugins.sbt
@@ -1,0 +1,10 @@
+resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
+  Resolver.ivyStylePatterns)
+
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.8.1"
+
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("uk.gov.hmrc" % "sbt-bobby" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-bobby/multi-project-build/test
+++ b/src/sbt-test/sbt-bobby/multi-project-build/test
@@ -1,0 +1,5 @@
+> project sub
+> validate
+$ exists target/bobby-reports/bobby-report.json
+$ exists target/bobby-reports/bobby-report.txt
+> check


### PR DESCRIPTION
When a project `dependsOn()` another, that dependent project gets added to the dependency graph as a `SNAPSHOT`. This can cause false violations of snapshot dependencies for multi-module builds.

This PR filters out the nodes to not include any project nodes