### PR TITLE
BDOG-1021: remove unused functions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
     sbtPlugin := true,
     name := "sbt-bobby",
     scalaVersion := "2.12.10",
-    crossSbtVersions := Vector("0.13.18", "1.3.4"),
+    crossSbtVersions := Vector("0.13.18", "1.3.13"),
     // Use the code from the sbt-dependency-graph plugin as if it was a standard library dependency
     // We use the plugin to resolve the complete module graph for the purpose of validating bobby
     // rule violations across transitive dependencies

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,8 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.co
 
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.13.0")

--- a/src/main/scala-sbt-1.0/uk/gov/hmrc/SbtCrossSupport.scala
+++ b/src/main/scala-sbt-1.0/uk/gov/hmrc/SbtCrossSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/SbtBobbyPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtBobbyPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/Bobby.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/Bobby.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/Bobby.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/Bobby.scala
@@ -61,17 +61,4 @@ object Bobby {
     if(config.strictMode && messages.exists(_.isWarning))
       throw new BobbyValidationFailedException("Build failed due to bobby warnings (strict mode is on). See previous output to resolve")
   }
-
-  private[bobby] def filterDependencies(dependencies: Seq[ModuleID], ignoreList: Set[String]): Seq[ModuleID] =
-    compactDependencies(dependencies)
-      .filterNot(m => ignoreList.contains(m.organization))
-
-  private[bobby] def compactDependencies(dependencies: Seq[ModuleID]): Seq[ModuleID] = {
-    import Util._
-    dependencies
-      .groupBy(_.moduleName)
-      .map(_._2.head)
-      .toSeq
-  }
-
 }

--- a/src/main/scala/uk/gov/hmrc/bobby/GraphOps.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/GraphOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/Http.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/Http.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/Util.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/Util.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/conf/BobbyConfiguration.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/conf/BobbyConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/conf/ConfigFile.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/conf/ConfigFile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/domain/BobbyRule.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/BobbyRule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/domain/BobbyValidator.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/BobbyValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/domain/Dependency.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/Dependency.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/domain/Message.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/Message.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/domain/MessageLevels.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/MessageLevels.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/domain/Version.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/Version.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/domain/VersionRange.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/VersionRange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/domain/bobby.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/domain/bobby.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/output/BobbyWriter.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/output/BobbyWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/output/ConsoleWriter.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/output/ConsoleWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/output/JsonFileWriter.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/output/JsonFileWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/output/Output.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/output/Output.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/output/Tabulator.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/output/Tabulator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/output/TextFileWriter.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/output/TextFileWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/output/TextWriter.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/output/TextWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/bobby/output/ViewType.scala
+++ b/src/main/scala/uk/gov/hmrc/bobby/output/ViewType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/BobbySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/BobbySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/BobbySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/BobbySpec.scala
@@ -16,37 +16,15 @@
 
 package uk.gov.hmrc.bobby
 
-import java.time.LocalDate
-
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sbt.ModuleID
 import uk.gov.hmrc.bobby.domain.MessageBuilder._
 import uk.gov.hmrc.bobby.domain.MessageLevels.{ERROR, INFO, WARN}
 import uk.gov.hmrc.bobby.domain._
 
+import java.time.LocalDate
+
 class BobbySpec extends AnyFlatSpec with Matchers {
-
-  it should "compact dependencies by only including them once if declared in multiple configurations" in {
-    val mods = Seq(
-      ModuleID("uk.gov.hmrc", "auth", "3.2.0").withConfigurations(Some("test")),
-      ModuleID("uk.gov.hmrc", "auth", "3.2.0"))
-
-    Bobby.compactDependencies(mods).size shouldBe 1
-  }
-
-  it should "prepare dependencies by removing any on a blacklist" in {
-    val auth = ModuleID("uk.gov.hmrc", "auth", "3.2.0")
-
-    val mods = Seq(
-      auth,
-      ModuleID("com.typesafe.play", "play-ws", "6.2.0")
-    )
-
-    val blacklisted: Set[String] = Set("com.typesafe.play")
-
-    Bobby.filterDependencies(mods, blacklisted) shouldBe Seq(auth)
-  }
 
   it should "order messages correctly" in {
     val rule = BobbyRule(Dependency("uk.gov.hmrc", "auth"), VersionRange("(,3.0.0]"), "testing", LocalDate.now())

--- a/src/test/scala/uk/gov/hmrc/bobby/Generators.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/Generators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/GraphOpsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/GraphOpsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/conf/ConfigurationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/conf/ConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/domain/BobbyValidatorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/domain/BobbyValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/domain/DependencyCheckerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/domain/DependencyCheckerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/domain/MessageBuilder.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/domain/MessageBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/domain/VersionRangeSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/domain/VersionRangeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/domain/VersionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/domain/VersionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/output/ConsoleWriterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/output/ConsoleWriterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/bobby/output/JsonFileWriterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/bobby/output/JsonFileWriterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
A test in `BobbySpec` used outdated terminology.  Upon closer inspection, the function under test was no longer used.